### PR TITLE
[IMPROVEMENT] (webida/webida-client#754) Synchronous XMLHttpRequest o…

### DIFF
--- a/js/config-loader.js
+++ b/js/config-loader.js
@@ -14,20 +14,27 @@
  * limitations under the License.
  */
 
+/**
+ * @file Get server-side configuration in advance of bootstrapping the app
+ *
+ * This is a kind of loader plugin of Require.js.
+ *
+ * @since 15. 12. 3
+ * @author Koong Kyungmi (kyungmi.k@samsung.com)
+ */
+
 define([
-    './config-loader!'
+    'webida'
 ], function (
-    serverConf
+    webida
 ) {
     'use strict';
 
-    var APP_ID = 'app-dashboard';
     return {
-        appId: APP_ID,
-        clientId: 'DASHBOARD_CLIENT_ID',
-        signUpEnable: !!serverConf.featureEnables.signUp,
-        guestMode: !!serverConf.featureEnables.guestMode,
-        redirectUrl: serverConf.systemApps[APP_ID].baseUrl + '/pages/auth.html',
-        ideBaseUrl: serverConf.systemApps['webida-client'].baseUrl
+        load: function (name, req, onLoad) {
+            req([webida.conf.appApiBaseUrl + '/configs?callback=define'], function (configs) {
+                onLoad(configs);
+            });
+        }
     };
 });


### PR DESCRIPTION
…n the main thread is deprecated (jQuery)

[DESC.]
- In jquery, synchronous ajax query was deprecated because of its bad effects to UX.
- So our Synchronous XMLHttpRequest in `app-config` is replaced with "loader plugin of Require.js" for loading server-side configs.
- It is more clear way to get configurations than before.
- This new `config-loader` loader plugin enables that `app-config` module can return value asynchronously.
